### PR TITLE
feat: add agent behavior metrics (#8)

### DIFF
--- a/src/agents/claude-code.ts
+++ b/src/agents/claude-code.ts
@@ -123,7 +123,7 @@ export class ClaudeCodeAgent implements AgentWrapper {
         disallowedTools: options.disallowedTools,
         maxBudgetUsd: options.maxBudgetUsd,
         maxTurns: options.maxTurns,
-        model: options.model,
+        model: options.model || 'claude-haiku-4-5-20251001',
         includePartialMessages: options.includePartialMessages ?? true,
         env: options.env,
         // Don't load user/project settings - isolation mode

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -199,6 +199,37 @@ export interface AgentRegistry {
 }
 
 /**
+ * Computed behavior metrics from agent execution
+ * These analyze HOW the agent works, not just what it produces
+ */
+export interface BehaviorMetrics {
+  /** Total tokens consumed */
+  totalTokens: number;
+  /** Number of tool calls */
+  toolCount: number;
+  /** Total cost in USD */
+  costUsd: number;
+  /** (Read+Glob+Grep calls) / total tools - research vs action */
+  explorationRatio: number;
+  /** Cache read tokens / total input tokens - context reuse */
+  cacheHitRatio: number;
+  /** Average tool execution time in ms (0 if timing unavailable) */
+  avgToolDurationMs: number;
+  /** Tokens per tool call */
+  tokensPerTool: number;
+  /** Tokens per Read tool call (file read efficiency) */
+  tokensPerRead: number;
+  /** Number of Read tool calls */
+  readCount: number;
+  /** Raw input tokens (non-cached) */
+  inputTokens: number;
+  /** Raw cache read tokens */
+  cacheReadTokens: number;
+  /** Raw cache write tokens */
+  cacheWriteTokens: number;
+}
+
+/**
  * Create empty token usage object
  */
 export function emptyTokenUsage(): TokenUsage {

--- a/src/metrics/behavior.ts
+++ b/src/metrics/behavior.ts
@@ -1,0 +1,83 @@
+/**
+ * Behavior metrics computation
+ *
+ * Analyzes HOW an agent works based on raw execution data.
+ * These metrics help understand agent efficiency and patterns.
+ */
+
+import { AgentResult, BehaviorMetrics } from '../agents/types.js';
+
+/** Tools considered "exploration" (read-only research) */
+const EXPLORATION_TOOLS = ['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch'];
+
+/**
+ * Compute behavior metrics from an agent result
+ */
+export function computeBehaviorMetrics(result: AgentResult): BehaviorMetrics {
+  const { tokens, costUsd, toolCalls } = result;
+
+  const safeToolCount = Math.max(toolCalls.length, 1);
+
+  // Exploration ratio: what fraction of tool calls are read-only research
+  const explorationCalls = toolCalls.filter((t) =>
+    EXPLORATION_TOOLS.includes(t.name)
+  ).length;
+  const explorationRatio = explorationCalls / safeToolCount;
+
+  // Cache hit ratio: fraction of input tokens that came from cache
+  // In Claude API: input_tokens = new tokens, cache_read_input_tokens = cached tokens
+  // Total input = input_tokens + cache_read_input_tokens
+  const totalInputTokens = tokens.inputTokens + tokens.cacheReadTokens;
+  const cacheHitRatio = totalInputTokens > 0
+    ? tokens.cacheReadTokens / totalInputTokens
+    : 0;
+
+
+  // Average tool duration (may be 0 if SDK doesn't provide timing)
+  const totalToolDuration = toolCalls.reduce(
+    (sum, t) => sum + (t.durationMs || 0),
+    0
+  );
+  const avgToolDurationMs = totalToolDuration / safeToolCount;
+
+  // Tokens per tool call
+  const tokensPerTool = tokens.totalTokens / safeToolCount;
+
+  // Count Read tool calls and compute tokens per read
+  const readCount = toolCalls.filter((t) => t.name === 'Read').length;
+  const tokensPerRead = readCount > 0 ? tokens.totalTokens / readCount : 0;
+
+  return {
+    totalTokens: tokens.totalTokens,
+    toolCount: toolCalls.length,
+    costUsd: Math.round(costUsd * 10000) / 10000, // 4 decimals
+    explorationRatio: Math.round(explorationRatio * 100) / 100, // 2 decimals
+    cacheHitRatio: Math.round(cacheHitRatio * 100) / 100,
+    avgToolDurationMs: Math.round(avgToolDurationMs),
+    tokensPerTool: Math.round(tokensPerTool),
+    tokensPerRead: Math.round(tokensPerRead),
+    readCount,
+    inputTokens: tokens.inputTokens,
+    cacheReadTokens: tokens.cacheReadTokens,
+    cacheWriteTokens: tokens.cacheWriteTokens,
+  };
+}
+
+/**
+ * Format behavior metrics for display
+ */
+export function formatBehaviorMetrics(metrics: BehaviorMetrics): string {
+  const lines = [
+    `    Tokens: ${metrics.totalTokens.toLocaleString()}    ` +
+      `Tools: ${metrics.toolCount}    ` +
+      `Cost: $${metrics.costUsd.toFixed(4)}`,
+    `    Tokens/tool: ${metrics.tokensPerTool.toLocaleString()}    ` +
+      `Tokens/read: ${metrics.tokensPerRead.toLocaleString()} (${metrics.readCount} reads)`,
+    `    Exploration Ratio: ${Math.round(metrics.explorationRatio * 100)}%    ` +
+      `Cache hits: ${Math.round(metrics.cacheHitRatio * 100)}%`,
+    `    Cache: input=${metrics.inputTokens.toLocaleString()} ` +
+      `read=${metrics.cacheReadTokens.toLocaleString()} ` +
+      `write=${metrics.cacheWriteTokens.toLocaleString()}`,
+  ];
+  return lines.join('\n');
+}

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Metrics module
+ *
+ * Provides computed metrics for analyzing agent behavior and performance.
+ */
+
+export * from './behavior.js';


### PR DESCRIPTION
Implement computed metrics that analyze HOW an agent works:
- totalTokens: tokens consumed for the case
- toolCount: number of tool calls
- costUsd: total cost
- explorationRatio: research vs action balance
- cacheHitRatio: context reuse efficiency
- tokensPerTool: tokens per tool call
- tokensPerRead: tokens per file read
- Raw cache token breakdown (input/read/write)

Uses case as the unit (not SDK-specific "turns"). Metrics are displayed after interview runs and stored in baselines.

Also:
- Default model set to claude-haiku-4-5-20251001
- Show model name in completion output
- Fix TUI interleaving when text streams between tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now display comprehensive behavior metrics after execution, including token usage, tool counts, estimated cost, cache hit ratios, and token efficiency metrics
  * Enhanced CLI output formatting to improve readability by preventing spinner and log conflicts during agent execution

* **Improvements**
  * Improved default model selection with automatic fallback to Claude Haiku when no model is specified

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->